### PR TITLE
Optimizes VR.

### DIFF
--- a/_maps/virtualreality/lavaland_brawl.dmm
+++ b/_maps/virtualreality/lavaland_brawl.dmm
@@ -6,7 +6,8 @@
 /area/template_noop)
 "b" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
 	},
 /area/template_noop)
 "c" = (
@@ -14,7 +15,8 @@
 	name = "FFA"
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
 	},
 /area/template_noop)
 "d" = (
@@ -28,7 +30,8 @@
 	name = "Team 2"
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
 	},
 /area/template_noop)
 "g" = (
@@ -36,7 +39,8 @@
 	name = "Team 1"
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
 	},
 /area/template_noop)
 

--- a/code/modules/virtual_reality/simulations/solidagent.dm
+++ b/code/modules/virtual_reality/simulations/solidagent.dm
@@ -27,7 +27,7 @@
 			if(!D.active) continue
 			if(get_turf(D) == D.disk_spawn) continue
 			if(D.loc == solid) continue
-			qdel(D)
+			D.recycle()
 
 
 	EquipCharacters()
@@ -179,7 +179,7 @@
 			sim.lock_down()
 			active = 1
 
-	Destroy()
+	proc/recycle()
 		if(sim && !qdeleted(sim) && !dontcheck)
 			sim.disks.Remove(src)
 			sim.intruder_alert("<span class='userdanger'>[src] has returned to its starting point</span>")
@@ -187,7 +187,7 @@
 			sim.disks.Add(S)
 			S.sim = sim
 			S.disk_spawn = S.disk_spawn
-		..()
+			qdel(src)
 
 	proc/check_disk()
 		if(istype(src,sim.target_type))

--- a/code/modules/virtual_reality/vr_manipulator.dm
+++ b/code/modules/virtual_reality/vr_manipulator.dm
@@ -182,6 +182,8 @@ var/global/list/vr_loaders = list()
 				MakeMob(user.client, /mob/camera/virtual_observer, get_turf(M))
 				qdel(user)
 
+		if(busy)
+			return
 		if(!loaded && !selected)
 			if(href_list["loadsim"])
 				selected = locate(href_list["loadsim"])

--- a/code/modules/virtual_reality/vr_manipulator.dm
+++ b/code/modules/virtual_reality/vr_manipulator.dm
@@ -42,6 +42,8 @@ var/global/list/vr_loaders = list()
 	var/list/simulations = list()
 	//
 	var/can_enter = 1
+	//
+	var/busy = 0
 
 	New()
 		..()
@@ -109,7 +111,9 @@ var/global/list/vr_loaders = list()
 		var/dat
 
 		dat += "<h3>Virtual Reality Manipulator</h3>"
-		if(loaded)
+		if(busy)
+			dat += "Recalibrating..."
+		else if(loaded)
 			dat += "In Progress:"
 			dat += "<div class='statusDisplay'>"
 			dat += "<u>[loaded.name]</u><br>"
@@ -251,6 +255,7 @@ var/global/list/vr_loaders = list()
 					SendToVRHub(C.mob)
 		qdel(loaded)
 		loaded = null
+		busy = 1
 		for(var/atom/movable/X in all_atoms)
 			if(istype(X, /obj/effect/landmark/vr_import))
 				continue
@@ -262,6 +267,7 @@ var/global/list/vr_loaders = list()
 				if(isobserver(X))
 					continue
 			qdel(X)
+			CHECK_TICK
 		//reset turfs
 		for(var/turf/T in get_area_turfs(vr_area))
 			T.ChangeTurf(/turf/closed/indestructible/void)
@@ -271,6 +277,7 @@ var/global/list/vr_loaders = list()
 		newarea.contents += get_area_turfs(vr_area)
 
 		update_icon()
+		busy = 0
 
 	proc/GetSimulationAtoms()
 		var/list/all_atoms = get_area_all_atoms(vr_area)

--- a/code/modules/virtual_reality/vr_manipulator.dm
+++ b/code/modules/virtual_reality/vr_manipulator.dm
@@ -175,6 +175,9 @@ var/global/list/vr_loaders = list()
 			return
 		if(!user.mind.virtual)
 			return
+		if(busy)
+			return
+
 		if(href_list["observesim"])
 			if(loaded && loaded.players.len)
 				var/mob/M = pick(loaded.players)
@@ -182,8 +185,6 @@ var/global/list/vr_loaders = list()
 				MakeMob(user.client, /mob/camera/virtual_observer, get_turf(M))
 				qdel(user)
 
-		if(busy)
-			return
 		if(!loaded && !selected)
 			if(href_list["loadsim"])
 				selected = locate(href_list["loadsim"])


### PR DESCRIPTION
-Disk re-spawning in solid agents are done via Tick() rather then Destroy()
-ClearSimulation() has CHECK_TICK now to lower the cost of deleting the VR zone
-Lavaland brawl no longer uses planetary atmos
